### PR TITLE
Add header and scoreboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <h1>Vežbač Enklitika</h1>
   <div class="sentence-container" id="sentence"></div>
   <div class="enclitic-options" id="encliticOptions"></div>
   <div class="buttons">
@@ -13,6 +14,13 @@
     <button onclick="checkAnswer()">✅ Gotovo</button>
   </div>
   <div id="feedback"></div>
+  <div class="scoreboard" id="scoreboard">
+    <div class="score-heading">Tačno</div>
+    <div class="score-heading">Netačno</div>
+    <div id="correct-tally" class="score-column"></div>
+    <div id="incorrect-tally" class="score-column"></div>
+  </div>
+  <div id="score-percent" class="score-percent"></div>
 
   <script src="enclitics-data.js"></script>
   <script>
@@ -21,6 +29,8 @@
     let insertedMap = {};
     // currently dragged element when moving from a slot
     let draggedEl = null;
+    let scoreCorrect = 0;
+    let scoreIncorrect = 0;
 
     function getNextIndex(idx) {
       const val = parseFloat(idx);
@@ -111,6 +121,41 @@
         e.dataTransfer.setData('source', 'bank');
       });
       document.getElementById('encliticOptions').appendChild(opt);
+    }
+
+    function renderTally(count) {
+      let html = '';
+      const groups = Math.floor(count / 5);
+      const remainder = count % 5;
+      for (let i = 0; i < groups; i++) {
+        html += `<div class="tally-block full">` +
+                `<span class="tally-bar"></span>` +
+                `<span class="tally-bar"></span>` +
+                `<span class="tally-bar"></span>` +
+                `<span class="tally-bar"></span>` +
+                `</div>`;
+      }
+      if (remainder) {
+        html += '<div class="tally-block">';
+        for (let i = 0; i < remainder; i++) {
+          html += '<span class="tally-bar"></span>';
+        }
+        html += '</div>';
+      }
+      return html;
+    }
+
+    function updateScoreboard(isCorrect) {
+      if (isCorrect === true) {
+        scoreCorrect++;
+      } else if (isCorrect === false) {
+        scoreIncorrect++;
+      }
+      document.getElementById('correct-tally').innerHTML = renderTally(scoreCorrect);
+      document.getElementById('incorrect-tally').innerHTML = renderTally(scoreIncorrect);
+      const total = scoreCorrect + scoreIncorrect;
+      const pct = total ? Math.round((scoreCorrect / total) * 100) : 0;
+      document.getElementById('score-percent').textContent = pct + '%';
     }
 
     function loadExample() {
@@ -315,9 +360,13 @@
 
       feedback.textContent = isCorrect ? '✅ Tačno!' : '❌ Nije tačno.';
       feedback.style.color = isCorrect ? 'green' : 'red';
+      updateScoreboard(isCorrect);
     }
 
-    document.addEventListener('DOMContentLoaded', loadExample);
+    document.addEventListener('DOMContentLoaded', () => {
+      updateScoreboard(null);
+      loadExample();
+    });
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -108,3 +108,75 @@ button {
   margin-top: 1rem;
   font-size: 1.1rem;
 }
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  font-size: 2rem;
+}
+
+.scoreboard {
+  width: 100%;
+  max-width: 300px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  background-color: #2e6139;
+  color: white;
+  margin-top: 2rem;
+  padding: 0.5rem;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.score-heading {
+  text-align: center;
+  border-bottom: 2px dashed #fff;
+  padding-bottom: 0.25rem;
+}
+
+.score-heading:first-child {
+  border-right: 2px dashed #fff;
+}
+
+.score-column {
+  min-height: 40px;
+  padding: 0.5rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.score-column:first-child {
+  border-right: 2px dashed #fff;
+}
+
+.tally-block {
+  display: flex;
+  position: relative;
+  width: 30px;
+  height: 20px;
+  gap: 2px;
+}
+
+.tally-bar {
+  width: 2px;
+  height: 100%;
+  background-color: white;
+}
+
+.tally-block.full::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background-color: white;
+  transform: translateY(-50%);
+}
+
+.score-percent {
+  color: white;
+  margin-top: 0.5rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add page header
- implement scoreboard with tallies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ffa347c788330a6a2f22924cea71b