### PR TITLE
Revamp scoreboard layout with chalkboard styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <title>Vežbač enklitika</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Gloria+Hallelujah&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -15,10 +18,14 @@
   </div>
   <div id="feedback"></div>
   <div class="scoreboard" id="scoreboard">
-    <div class="score-heading">Tačno</div>
-    <div class="score-heading">Netačno</div>
-    <div id="correct-tally" class="score-column"></div>
-    <div id="incorrect-tally" class="score-column"></div>
+    <div class="score-side">
+      <div class="score-heading">Tačno</div>
+      <div id="correct-tally" class="score-column"></div>
+    </div>
+    <div class="score-side">
+      <div class="score-heading">Nije tačno</div>
+      <div id="incorrect-tally" class="score-column"></div>
+    </div>
   </div>
   <div id="score-percent" class="score-percent"></div>
 

--- a/style.css
+++ b/style.css
@@ -116,23 +116,29 @@ h1 {
 .scoreboard {
   width: 100%;
   max-width: 500px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto auto;
+  display: flex;
+  justify-content: space-between;
   color: white;
   margin-top: 2rem;
   padding: 0.5rem;
-  font-family: 'Segoe UI', sans-serif;
+}
+
+.score-side {
+  flex: 1 1 45%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.score-side:first-child {
+  border-right: 2px dashed #fff;
 }
 
 .score-heading {
   text-align: center;
   border-bottom: 2px dashed #fff;
   padding-bottom: 0.25rem;
-}
-
-.score-heading:first-child {
-  border-right: 2px dashed #fff;
+  font-family: 'Gloria Hallelujah', cursive;
 }
 
 .score-column {
@@ -144,9 +150,6 @@ h1 {
   gap: 6px;
 }
 
-.score-column:first-child {
-  border-right: 2px dashed #fff;
-}
 
 .tally-block {
   display: flex;
@@ -161,6 +164,8 @@ h1 {
   height: 100%;
   margin: 2px;
   background-color: white;
+  transform: rotate(-5deg);
+  font-family: 'Gloria Hallelujah', cursive;
 }
 
 .tally-block.full::after {
@@ -171,11 +176,12 @@ h1 {
   width: 100%;
   height: 2px;
   background-color: white;
-  transform: translateY(-50%);
+  transform: translateY(-50%) rotate(-10deg);
 }
 
 .score-percent {
   color: white;
   margin-top: 0.5rem;
   font-weight: bold;
+  font-family: 'Gloria Hallelujah', cursive;
 }


### PR DESCRIPTION
## Summary
- load Google Fonts for a chalkboard look
- restructure scoreboard markup
- change second heading text to `Nije tačno`
- redesign scoreboard layout with flexbox
- slant tally lines and apply chalkboard font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f60a2bf88330895d8296f97d3d5e