### PR TITLE
Display translations for examples

### DIFF
--- a/enclitics-data.js
+++ b/enclitics-data.js
@@ -1,8 +1,9 @@
 const encliticsExamples = [
-  { 
+  {
     "parts": ["Petar", "juče", "dao", "poklon", "djete"],
     "enclitics": ["mu", "je", "za"],
     "distractors": ["ga", "se"],
-    "correctIndexes": [1, 1.1, 4]
+    "correctIndexes": [1, 1.1, 4],
+    "translation": "Peter gave him a gift for the child yesterday."
   },
 ];

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <body>
   <h1>Vežbač Enklitika</h1>
   <div class="sentence-container" id="sentence"></div>
+  <div id="translation" class="translation"></div>
   <div class="enclitic-options" id="encliticOptions"></div>
   <div class="buttons">
     <button onclick="checkAnswer()">🙋 Gotovo</button>
@@ -168,6 +169,9 @@
       feedback.textContent = '';
 
       currentExample = encliticsExamples[Math.floor(Math.random() * encliticsExamples.length)];
+
+      const translationEl = document.getElementById('translation');
+      translationEl.textContent = currentExample.translation || '';
 
       currentExample.parts.forEach((word, i) => {
         const wordBlock = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -17,6 +17,13 @@ body {
   margin-bottom: 2rem;
 }
 
+.translation {
+  color: white;
+  margin-bottom: 1rem;
+  font-style: italic;
+  text-align: center;
+}
+
 .word-block {
   background-color: #d0f0c0;
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- add `translation` key to example data
- show translation block in HTML
- update JS to populate the translation
- style the translation block

## Testing
- `node -e "require('./enclitics-data.js');"`

------
https://chatgpt.com/codex/tasks/task_e_6880f608fc8083309ff90e1227948661