### PR TITLE
Fix slot loss when moving base left

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,6 +314,10 @@
             draggedEl.remove();
             fromSlot.classList.remove('has-enclitic');
 
+          const movingBaseLeft =
+            !from.includes('.') && idx.startsWith('-') &&
+            Math.abs(parseFloat(from)) === Math.abs(parseFloat(idx));
+
           const fromIdx = parseFloat(fromSlot.dataset.index);
           const sameBase = Math.floor(fromIdx) === Math.floor(parseFloat(idx));
           const isImmediate = fromSlot.nextElementSibling === dropSlot;
@@ -327,6 +331,8 @@
               delete insertedMap[oldIdx];
             }
             renumberFollowingSlots(dropSlot.nextElementSibling);
+          } else if (movingBaseLeft) {
+            fromSlot.remove();
           } else {
             removeSlotIfNeeded(fromSlot);
           }
@@ -337,9 +343,20 @@
 
           if (idx.startsWith('-')) {
             const baseIdx = Math.abs(parseInt(idx));
-            shiftGroupRight(baseIdx, dropSlot.parentElement);
-            dropSlot.dataset.index = baseIdx;
-            idx = dropSlot.dataset.index;
+            if (source === 'slot' && parseFloat(from) === baseIdx) {
+              const oldBase = document.querySelector(
+                `.drop-slot[data-index="${baseIdx}"]`
+              );
+              if (oldBase && oldBase !== dropSlot) {
+                oldBase.remove();
+              }
+              dropSlot.dataset.index = baseIdx;
+              idx = dropSlot.dataset.index;
+            } else {
+              shiftGroupRight(baseIdx, dropSlot.parentElement);
+              dropSlot.dataset.index = baseIdx;
+              idx = dropSlot.dataset.index;
+            }
           }
 
         // Remove same enclitic from other slots (only one instance allowed)


### PR DESCRIPTION
## Summary
- avoid removing trailing sub-slot when moving an enclitic from its base slot to the left slot

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688123b4954483308b0809d1b710aa82