### PR TITLE
Fix slot loss when moving base left

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,26 +9,27 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Vežbač Enklitika</h1>
-  <div class="sentence-container" id="sentence"></div>
-  <div id="translation" class="translation"></div>
-  <div class="enclitic-options" id="encliticOptions"></div>
-  <div class="buttons">
-    <button onclick="checkAnswer()">🙋 Gotovo</button>
-    <button onclick="loadExample()">🤦 Novi primjer</button>
+  <div class="score-side">
+    <div class="score-heading">Tačno</div>
+    <div id="correct-tally" class="score-column"></div>
   </div>
-  <div id="feedback"></div>
-  <div class="scoreboard" id="scoreboard">
-    <div class="score-side">
-      <div class="score-heading">Tačno</div>
-      <div id="correct-tally" class="score-column"></div>
+  <div class="main-container">
+    <h1>Vežbač Enklitika</h1>
+    <div class="sentence-container" id="sentence"></div>
+    <div id="translation" class="translation"></div>
+    <div class="enclitic-options" id="encliticOptions"></div>
+    <div class="buttons">
+      <button onclick="checkAnswer()">🙋 Gotovo</button>
+      <button onclick="loadExample()">🤦 Novi primjer</button>
     </div>
-    <div class="score-side">
-      <div class="score-heading">Nije tačno</div>
-      <div id="incorrect-tally" class="score-column"></div>
-    </div>
+    <div id="score-percent" class="score-percent"></div>
+    <button id="reset-score" onclick="resetScore()">Сброс</button>
+    <div id="feedback"></div>
   </div>
-  <div id="score-percent" class="score-percent"></div>
+  <div class="score-side">
+    <div class="score-heading">Nije tačno</div>
+    <div id="incorrect-tally" class="score-column"></div>
+  </div>
 
   <script src="enclitics-data.js"></script>
   <script>
@@ -211,6 +212,12 @@
       document.getElementById('score-percent').textContent = pct + '%';
     }
 
+    function resetScore() {
+      scoreCorrect = 0;
+      scoreIncorrect = 0;
+      updateScoreboard(null);
+    }
+
     function loadExample() {
       insertedMap = {};
       const sentence = document.getElementById('sentence');
@@ -314,6 +321,10 @@
             draggedEl.remove();
             fromSlot.classList.remove('has-enclitic');
 
+          const movingBaseLeft =
+            !from.includes('.') && idx.startsWith('-') &&
+            Math.abs(parseFloat(from)) === Math.abs(parseFloat(idx));
+
           const fromIdx = parseFloat(fromSlot.dataset.index);
           const sameBase = Math.floor(fromIdx) === Math.floor(parseFloat(idx));
           const isImmediate = fromSlot.nextElementSibling === dropSlot;
@@ -327,6 +338,8 @@
               delete insertedMap[oldIdx];
             }
             renumberFollowingSlots(dropSlot.nextElementSibling);
+          } else if (movingBaseLeft) {
+            fromSlot.remove();
           } else {
             removeSlotIfNeeded(fromSlot);
           }
@@ -337,9 +350,20 @@
 
           if (idx.startsWith('-')) {
             const baseIdx = Math.abs(parseInt(idx));
-            shiftGroupRight(baseIdx, dropSlot.parentElement);
-            dropSlot.dataset.index = baseIdx;
-            idx = dropSlot.dataset.index;
+            if (source === 'slot' && parseFloat(from) === baseIdx) {
+              const oldBase = document.querySelector(
+                `.drop-slot[data-index="${baseIdx}"]`
+              );
+              if (oldBase && oldBase !== dropSlot) {
+                oldBase.remove();
+              }
+              dropSlot.dataset.index = baseIdx;
+              idx = dropSlot.dataset.index;
+            } else {
+              shiftGroupRight(baseIdx, dropSlot.parentElement);
+              dropSlot.dataset.index = baseIdx;
+              idx = dropSlot.dataset.index;
+            }
           }
 
         // Remove same enclitic from other slots (only one instance allowed)

--- a/style.css
+++ b/style.css
@@ -1,12 +1,19 @@
-body { 
+body {
   font-family: 'Segoe UI', sans-serif;
   font-size: 18px;
   background-color: #013220;
   margin: 0;
   padding: 2rem;
   display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.main-container {
+  display: flex;
   flex-direction: column;
   align-items: center;
+  margin: 0 2rem;
 }
 
 .sentence-container {
@@ -131,14 +138,16 @@ h1 {
 }
 
 .score-side {
-  flex: 1 1 45%;
+  width: 150px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  color: white;
+  margin: 0 1rem;
 }
 
 .score-side:first-child {
-  border-right: 2px dashed #fff;
+  border-right: none;
 }
 
 .score-heading {


### PR DESCRIPTION
## Summary
- avoid removing trailing sub-slot when moving an enclitic from its base slot to the left slot
- place scoreboard columns on the sides with a central container
- show percent correct and a Reset button under the main buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688123b4954483308b0809d1b710aa82