### PR TITLE
Reset heading color with score reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,26 +9,28 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Vežbač Enklitika</h1>
-  <div class="sentence-container" id="sentence"></div>
-  <div id="translation" class="translation"></div>
-  <div class="enclitic-options" id="encliticOptions"></div>
-  <div class="buttons">
-    <button onclick="checkAnswer()">🙋 Gotovo</button>
-    <button onclick="loadExample()">🤦 Novi primjer</button>
+  <div class="score-side">
+    <div id="correct-heading" class="score-heading">Tačno</div>
+    <div id="correct-tally" class="score-column"></div>
   </div>
-  <div id="feedback"></div>
-  <div class="scoreboard" id="scoreboard">
-    <div class="score-side">
-      <div class="score-heading">Tačno</div>
-      <div id="correct-tally" class="score-column"></div>
+  <div class="main-container">
+    <h1>Vežbač Enklitika</h1>
+    <div class="sentence-container" id="sentence"></div>
+    <div id="translation" class="translation"></div>
+    <div class="enclitic-options" id="encliticOptions"></div>
+    <div class="buttons">
+      <button onclick="checkAnswer()">🙋 Gotovo</button>
+      <button onclick="loadExample()">🤦 Novi primjer</button>
     </div>
-    <div class="score-side">
-      <div class="score-heading">Nije tačno</div>
-      <div id="incorrect-tally" class="score-column"></div>
+    <div class="score-percent">
+      <button id="reset-score" onclick="resetScore()">🔄</button>
+      <span id="score-text">0%</span> правильных ответов
     </div>
   </div>
-  <div id="score-percent" class="score-percent"></div>
+  <div class="score-side">
+    <div id="incorrect-heading" class="score-heading">Nije tačno</div>
+    <div id="incorrect-tally" class="score-column"></div>
+  </div>
 
   <script src="enclitics-data.js"></script>
   <script>
@@ -208,17 +210,29 @@
       document.getElementById('incorrect-tally').innerHTML = renderTally(scoreIncorrect);
       const total = scoreCorrect + scoreIncorrect;
       const pct = total ? Math.round((scoreCorrect / total) * 100) : 0;
-      document.getElementById('score-percent').textContent = pct + '%';
+      document.getElementById('score-text').textContent = pct + '%';
     }
+
+   function resetScore() {
+     scoreCorrect = 0;
+     scoreIncorrect = 0;
+      const ch = document.getElementById('correct-heading');
+      const ih = document.getElementById('incorrect-heading');
+      ch.classList.remove('correct-heading', 'incorrect-heading');
+      ih.classList.remove('correct-heading', 'incorrect-heading');
+      updateScoreboard(null);
+   }
 
     function loadExample() {
       insertedMap = {};
       const sentence = document.getElementById('sentence');
       const encliticOptions = document.getElementById('encliticOptions');
-      const feedback = document.getElementById('feedback');
+      const ch = document.getElementById('correct-heading');
+      const ih = document.getElementById('incorrect-heading');
       sentence.innerHTML = '';
       encliticOptions.innerHTML = '';
-      feedback.textContent = '';
+      ch.classList.remove('correct-heading', 'incorrect-heading');
+      ih.classList.remove('correct-heading', 'incorrect-heading');
 
       currentExample = encliticsExamples[Math.floor(Math.random() * encliticsExamples.length)];
 
@@ -314,6 +328,10 @@
             draggedEl.remove();
             fromSlot.classList.remove('has-enclitic');
 
+          const movingBaseLeft =
+            !from.includes('.') && idx.startsWith('-') &&
+            Math.abs(parseFloat(from)) === Math.abs(parseFloat(idx));
+
           const fromIdx = parseFloat(fromSlot.dataset.index);
           const sameBase = Math.floor(fromIdx) === Math.floor(parseFloat(idx));
           const isImmediate = fromSlot.nextElementSibling === dropSlot;
@@ -327,6 +345,8 @@
               delete insertedMap[oldIdx];
             }
             renumberFollowingSlots(dropSlot.nextElementSibling);
+          } else if (movingBaseLeft) {
+            fromSlot.remove();
           } else {
             removeSlotIfNeeded(fromSlot);
           }
@@ -337,9 +357,20 @@
 
           if (idx.startsWith('-')) {
             const baseIdx = Math.abs(parseInt(idx));
-            shiftGroupRight(baseIdx, dropSlot.parentElement);
-            dropSlot.dataset.index = baseIdx;
-            idx = dropSlot.dataset.index;
+            if (source === 'slot' && parseFloat(from) === baseIdx) {
+              const oldBase = document.querySelector(
+                `.drop-slot[data-index="${baseIdx}"]`
+              );
+              if (oldBase && oldBase !== dropSlot) {
+                oldBase.remove();
+              }
+              dropSlot.dataset.index = baseIdx;
+              idx = dropSlot.dataset.index;
+            } else {
+              shiftGroupRight(baseIdx, dropSlot.parentElement);
+              dropSlot.dataset.index = baseIdx;
+              idx = dropSlot.dataset.index;
+            }
           }
 
         // Remove same enclitic from other slots (only one instance allowed)
@@ -408,7 +439,8 @@
     }
 
     function checkAnswer() {
-      const feedback = document.getElementById('feedback');
+      const ch = document.getElementById('correct-heading');
+      const ih = document.getElementById('incorrect-heading');
       const insertedPairs = [];
       Object.keys(insertedMap)
         .sort((a, b) => parseFloat(a) - parseFloat(b))
@@ -434,8 +466,13 @@
         }
       });
 
-      feedback.textContent = isCorrect ? '✅ Tačno!' : '❌ Nije tačno.';
-      feedback.style.color = isCorrect ? 'green' : 'red';
+      ch.classList.remove('correct-heading', 'incorrect-heading');
+      ih.classList.remove('correct-heading', 'incorrect-heading');
+      if (isCorrect) {
+        ch.classList.add('correct-heading');
+      } else {
+        ih.classList.add('incorrect-heading');
+      }
       updateScoreboard(isCorrect);
     }
 

--- a/style.css
+++ b/style.css
@@ -1,12 +1,19 @@
-body { 
+body {
   font-family: 'Segoe UI', sans-serif;
   font-size: 18px;
   background-color: #013220;
   margin: 0;
   padding: 2rem;
   display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.main-container {
+  display: flex;
   flex-direction: column;
   align-items: center;
+  margin: 0 2rem;
 }
 
 .sentence-container {
@@ -131,14 +138,16 @@ h1 {
 }
 
 .score-side {
-  flex: 1 1 45%;
+  width: 150px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  color: white;
+  margin: 0 3rem;
 }
 
 .score-side:first-child {
-  border-right: 2px dashed #fff;
+  border-right: none;
 }
 
 .score-heading {
@@ -146,6 +155,17 @@ h1 {
   border-bottom: 2px dashed #fff;
   padding-bottom: 0.25rem;
   font-family: 'Gloria Hallelujah', cursive;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.correct-heading {
+  color: #7CFC00;
+  transform: scale(1.2);
+}
+
+.incorrect-heading {
+  color: #ff4d4d;
+  transform: scale(1.2);
 }
 
 .score-column {
@@ -186,9 +206,32 @@ h1 {
   transform: translateY(-50%) rotate(-10deg);
 }
 
+
 .score-percent {
   color: white;
   margin-top: 0.5rem;
   font-weight: bold;
   font-family: 'Gloria Hallelujah', cursive;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#reset-score {
+  background-color: #eee;
+  color: #013220;
+  border: 2px solid #ccc;
+  border-radius: 6px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+#reset-score:hover {
+  background-color: #e0e0e0;
 }


### PR DESCRIPTION
## Summary
- show reset button and score text together
- update scoreboard text to show "правильных ответов"
- reset scoreboard header highlights when clearing the score
- restyle the reset button as a simple square icon

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688123b4954483308b0809d1b710aa82