### PR TITLE
Update reset button style, scoreboard layout and slot indexing

### DIFF
--- a/enclitics-data.js
+++ b/enclitics-data.js
@@ -3,7 +3,7 @@ const encliticsExamples = [
     "parts": ["Petar", "juče", "dao", "poklon", "djete"],
     "enclitics": ["mu", "je", "za"],
     "distractors": ["ga", "se"],
-    "correctIndexes": [1, 1.1, 4],
+    "correctIndexes": [2, 2.1, 5],
     "translation": "Петар дал ему вчера подарок для ребёнка."
   },
 ];

--- a/index.html
+++ b/index.html
@@ -239,19 +239,18 @@
       const translationEl = document.getElementById('translation');
       translationEl.textContent = currentExample.translation || '';
 
+      const firstSlot = createDropSlot(1);
+      sentence.appendChild(firstSlot);
+
       currentExample.parts.forEach((word, i) => {
         const wordBlock = document.createElement('div');
         wordBlock.className = 'word-block';
         wordBlock.textContent = word;
         sentence.appendChild(wordBlock);
 
-        const dropSlot = createDropSlot(i + 1);
+        const dropSlot = createDropSlot(i + 2);
         sentence.appendChild(dropSlot);
       });
-
-      // Extra slot after last word
-      const lastSlot = createDropSlot(currentExample.parts.length + 1);
-      sentence.appendChild(lastSlot);
 
       // Create draggable enclitics
       const allOptions = [...currentExample.enclitics, ...currentExample.distractors].sort(() => Math.random() - 0.5);

--- a/style.css
+++ b/style.css
@@ -177,6 +177,11 @@ h1 {
   gap: 6px;
 }
 
+#incorrect-tally {
+  margin: 0.5rem;
+  margin-right: 0.5rem;
+}
+
 
 .tally-block {
   display: flex;
@@ -209,7 +214,7 @@ h1 {
 
 .score-percent {
   color: white;
-  margin-top: 0.5rem;
+  margin-top: 1rem;
   font-weight: bold;
   font-family: 'Gloria Hallelujah', cursive;
   display: flex;
@@ -218,37 +223,5 @@ h1 {
 }
 
 #reset-score {
-  background-color: #eee;
-  color: #013220;
-  border: 2px solid #ccc;
-  border-radius: 6px;
-  width: 40px;
-  height: 40px;
-  padding: 0;
-  font-size: 1.2rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-
-#reset-score:hover {
-  background-color: #e0e0e0;
-}
-
-#reset-score {
-  background-color: #eee;
-  color: #013220;
-  border: 2px solid #ccc;
-  border-radius: 0 0 10px 10px;
-  padding: 0.4rem 1rem;
-  font-family: 'Gloria Hallelujah', cursive;
-  transform: rotate(-3deg);
-  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-  margin-top: 0.5rem;
-  cursor: pointer;
-}
-
-#reset-score:hover {
-  background-color: #e0e0e0;
+  background-color: #ff6b81;
 }


### PR DESCRIPTION
## Summary
- tweak `reset-score` button style to match other buttons
- add margin tweaks for incorrect tally and scoreboard placement
- add initial drop slot and update indexes
- fix sample answer indexes

## Testing
- `node -e "require('./enclitics-data.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_688224e2aa4883308d63ac7451ff806d