### PR TITLE
Fix scoreboard layout and button styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="score-side">
+  <div class="score-side left-side">
     <div id="correct-heading" class="score-heading">Tačno</div>
     <div id="correct-tally" class="score-column"></div>
   </div>
@@ -28,7 +28,7 @@
       <span id="score-text">0%</span> правильных ответов
     </div>
   </div>
-  <div class="score-side">
+  <div class="score-side right-side">
     <div id="incorrect-heading" class="score-heading">Nije tačno</div>
     <div id="incorrect-tally" class="score-column"></div>
   </div>

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 0 2rem;
+  margin: 0 12rem;
 }
 
 .sentence-container {
@@ -143,11 +143,16 @@ h1 {
   flex-direction: column;
   align-items: center;
   color: white;
-  margin: 0 3rem;
+  position: fixed;
+  top: 2rem;
 }
 
-.score-side:first-child {
-  border-right: none;
+.left-side {
+  left: 2rem;
+}
+
+.right-side {
+  right: 2rem;
 }
 
 .score-heading {
@@ -189,6 +194,7 @@ h1 {
   width: 30px;
   height: 45px;
   gap: 2px;
+  margin: 0.3rem;
 }
 
 .tally-bar {
@@ -224,4 +230,11 @@ h1 {
 
 #reset-score {
   background-color: #ff6b81;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- keep scoreboards fixed on screen
- adjust spacing for main content
- add margin for tally blocks
- resize reset button to square

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68833dd3f1d883309efedc4c9619bc7a