### PR TITLE
Add fade animations for new examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <div class="enclitic-options" id="encliticOptions"></div>
     <div class="buttons">
       <button id="check-button" onclick="checkAnswer()">🙋 Gotovo</button>
-      <button id="new-example" onclick="loadExample()">Novi primjer</button>
+      <button id="new-example" onclick="loadExample(true)">Novi primjer</button>
     </div>
     <div class="score-percent">
       <button id="reset-score" onclick="resetScore()">🔄</button>

--- a/script.js
+++ b/script.js
@@ -188,62 +188,85 @@
       loadExample();
    }
 
-    function loadExample() {
-      document.getElementById('check-button').disabled = false;
-      insertedMap = {};
+   function loadExample(animated = false) {
+      const checkBtn = document.getElementById('check-button');
       const sentence = document.getElementById('sentence');
       const encliticOptions = document.getElementById('encliticOptions');
       const ch = document.getElementById('correct-heading');
       const ih = document.getElementById('incorrect-heading');
-      sentence.innerHTML = '';
-      encliticOptions.innerHTML = '';
-      ch.classList.remove('correct-heading', 'incorrect-heading');
-      ih.classList.remove('correct-heading', 'incorrect-heading');
-
-      currentExample = encliticsExamples[Math.floor(Math.random() * encliticsExamples.length)];
-
       const translationEl = document.getElementById('translation');
-      translationEl.textContent = currentExample.translation || '';
 
-      const firstSlot = createDropSlot(1);
-      sentence.appendChild(firstSlot);
+      const build = () => {
+        checkBtn.disabled = false;
+        insertedMap = {};
+        sentence.innerHTML = '';
+        encliticOptions.innerHTML = '';
+        ch.classList.remove('correct-heading', 'incorrect-heading');
+        ih.classList.remove('correct-heading', 'incorrect-heading');
 
-      currentExample.parts.forEach((word, i) => {
-        const wordBlock = document.createElement('div');
-        wordBlock.className = 'word-block';
-        wordBlock.textContent = word;
-        sentence.appendChild(wordBlock);
+        currentExample = encliticsExamples[Math.floor(Math.random() * encliticsExamples.length)];
 
-        const dropSlot = createDropSlot(i + 2);
-        sentence.appendChild(dropSlot);
-      });
+        translationEl.textContent = currentExample.translation || '';
 
-      // Create draggable enclitics
-      const allOptions = [...currentExample.enclitics, ...currentExample.distractors].sort(() => Math.random() - 0.5);
-      allOptions.forEach(text => createOption(text));
+        const firstSlot = createDropSlot(1);
+        sentence.appendChild(firstSlot);
 
-      // Allow dropping enclitics back to bank
-      encliticOptions.ondragover = e => e.preventDefault();
-      encliticOptions.ondrop = e => {
-        e.preventDefault();
-        const enclitic = e.dataTransfer.getData('text/plain');
-        const source = e.dataTransfer.getData('source');
-        const from = e.dataTransfer.getData('from');
+        currentExample.parts.forEach((word, i) => {
+          const wordBlock = document.createElement('div');
+          wordBlock.className = 'word-block';
+          wordBlock.textContent = word;
+          sentence.appendChild(wordBlock);
 
-        if (source === 'slot' && draggedEl) {
-          const slot = draggedEl.parentElement;
-          draggedEl.remove();
-          slot.classList.remove('has-enclitic');
-          const arr = insertedMap[from] || [];
-          insertedMap[from] = arr.filter(el => el !== draggedEl);
-          if (!insertedMap[from].length) delete insertedMap[from];
-          removeSlotIfNeeded(slot);
-          const baseFrom = Math.floor(Math.abs(parseFloat(from)));
-          cleanupAfterRemoval(baseFrom);
-          draggedEl = null;
-          createOption(enclitic);
-        }
+          const dropSlot = createDropSlot(i + 2);
+          sentence.appendChild(dropSlot);
+        });
+
+        // Create draggable enclitics
+        const allOptions = [...currentExample.enclitics, ...currentExample.distractors].sort(() => Math.random() - 0.5);
+        allOptions.forEach(text => createOption(text));
+
+        // Allow dropping enclitics back to bank
+        encliticOptions.ondragover = e => e.preventDefault();
+        encliticOptions.ondrop = e => {
+          e.preventDefault();
+          const enclitic = e.dataTransfer.getData('text/plain');
+          const source = e.dataTransfer.getData('source');
+          const from = e.dataTransfer.getData('from');
+
+          if (source === 'slot' && draggedEl) {
+            const slot = draggedEl.parentElement;
+            draggedEl.remove();
+            slot.classList.remove('has-enclitic');
+            const arr = insertedMap[from] || [];
+            insertedMap[from] = arr.filter(el => el !== draggedEl);
+            if (!insertedMap[from].length) delete insertedMap[from];
+            removeSlotIfNeeded(slot);
+            const baseFrom = Math.floor(Math.abs(parseFloat(from)));
+            cleanupAfterRemoval(baseFrom);
+            draggedEl = null;
+            createOption(enclitic);
+          }
+        };
       };
+
+      if (animated) {
+        ch.classList.remove('correct-heading', 'incorrect-heading');
+        ih.classList.remove('correct-heading', 'incorrect-heading');
+        [sentence, encliticOptions, translationEl].forEach(el => el.classList.add('fade-out'));
+        setTimeout(() => {
+          [sentence, encliticOptions, translationEl].forEach(el => {
+            el.classList.remove('fade-out');
+          });
+          build();
+          [sentence, encliticOptions, translationEl].forEach(el => el.classList.add('fade-in'));
+          setTimeout(() => {
+            [sentence, encliticOptions, translationEl].forEach(el => el.classList.remove('fade-in'));
+          }, 300);
+        }, 300);
+        return;
+      }
+
+      build();
     }
 
     function createDropSlot(index) {

--- a/style.css
+++ b/style.css
@@ -75,6 +75,38 @@ body {
   }
 }
 
+@keyframes fade-out-scale {
+  from {
+    opacity: 1;
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.5);
+    filter: brightness(0.7);
+  }
+}
+
+@keyframes fade-in-scale {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.fade-out {
+  animation: fade-out-scale 0.3s forwards;
+}
+
+.fade-in {
+  animation: fade-in-scale 0.3s forwards;
+}
+
 .main-container {
   display: flex;
   flex-direction: column;
@@ -181,6 +213,7 @@ button {
   cursor: pointer;
   font-size: 1rem;
   margin: 0.5rem;
+  transition: background-color 0.3s ease, transform 0.3s ease;
 }
 
 .buttons {
@@ -237,7 +270,7 @@ h1 {
   border-bottom: 2px dashed #fff;
   padding-bottom: 0.25rem;
   font-family: 'Gloria Hallelujah', cursive;
-  transition: transform 0.2s ease, color 0.2s ease;
+  transition: transform 0.4s ease, color 0.4s ease;
 }
 
 .correct-heading {


### PR DESCRIPTION
## Summary
- animate enabling of the **Gotovo** button
- smooth transition of score headings back to default
- fade old example out and new example in when pressing *Novi primjer*

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68877307476c8330a8b4a59026c86715