### PR TITLE
Update reset icon size and scoreboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     </div>
     <div class="score-percent">
       <button id="reset-score" onclick="resetScore()">
-        <svg fill="#ffffff" viewBox="0 0 512 512" data-name="Layer 1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M64,256H34A222,222,0,0,1,430,118.15V85h30V190H355V160h67.27A192.21,192.21,0,0,0,256,64C150.13,64,64,150.13,64,256Zm384,0c0,105.87-86.13,192-192,192A192.21,192.21,0,0,1,89.73,352H157V322H52V427H82V393.85A222,222,0,0,0,478,256Z"></path></g></svg>
+        <svg fill="#000000" stroke="#000000" width="1.5rem" height="1.5rem" viewBox="0 0 512 512" data-name="Layer 1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M64,256H34A222,222,0,0,1,430,118.15V85h30V190H355V160h67.27A192.21,192.21,0,0,0,256,64C150.13,64,64,150.13,64,256Zm384,0c0,105.87-86.13,192-192,192A192.21,192.21,0,0,1,89.73,352H157V322H52V427H82V393.85A222,222,0,0,0,478,256Z"></path></g></svg>
       </button>
       <span id="score-text">0%</span> правильных ответов
     </div>

--- a/style.css
+++ b/style.css
@@ -277,10 +277,12 @@ h1 {
 
 .left-side {
   left: 2rem;
+  margin-left: 4rem;
 }
 
 .right-side {
   right: 2rem;
+  margin-right: 4rem;
 }
 
 .score-heading {


### PR DESCRIPTION
## Summary
- shrink the reset-score SVG and change its color to black
- add margins to the left and right scoreboard columns

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6887a64eebe883308843603c608b94d3