### PR TITLE
Adjust auto-delay button layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -392,16 +392,19 @@ h1 {
   justify-content: center;
 }
 
+/* Check button container layout */
 .check-container {
   position: relative;
   width: fit-content;
+  display: flex;
+  justify-content: center;
 }
 
 #auto-delay-button {
   width: 2rem;
   height: 2rem;
   padding: 0;
-  border-radius: 6px;
+  border-radius: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -409,4 +412,9 @@ h1 {
   left: calc(100% + 0.5rem);
   top: 50%;
   transform: translateY(-50%);
+}
+
+#auto-delay-button svg {
+  fill: #000;
+  stroke: #000;
 }


### PR DESCRIPTION
## Summary
- center the `#check-button` container
- restyle `#auto-delay-button` to be square
- ensure auto-delay icons are black

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6887f876aba083309b051cc9af58cb35