### PR TITLE
Update reset score icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     </div>
     <div class="score-percent">
       <button id="reset-score" onclick="resetScore()">
-        <svg fill="#000000" stroke="#000000" width="1.5rem" height="1.5rem" viewBox="0 0 512 512" data-name="Layer 1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M64,256H34A222,222,0,0,1,430,118.15V85h30V190H355V160h67.27A192.21,192.21,0,0,0,256,64C150.13,64,64,150.13,64,256Zm384,0c0,105.87-86.13,192-192,192A192.21,192.21,0,0,1,89.73,352H157V322H52V427H82V393.85A222,222,0,0,0,478,256Z"></path></g></svg>
+        <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#000000" stroke-width="1"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M17 9a1 1 0 01-1-1c0-.551-.448-1-1-1H5.414l1.293 1.293a.999.999 0 11-1.414 1.414l-3-3a.999.999 0 010-1.414l3-3a.997.997 0 011.414 0 .999.999 0 010 1.414L5.414 5H15c1.654 0 3 1.346 3 3a1 1 0 01-1 1zM3 11a1 1 0 011 1c0 .551.448 1 1 1h9.586l-1.293-1.293a.999.999 0 111.414-1.414l3 3a.999.999 0 010 1.414l-3 3a.999.999 0 11-1.414-1.414L14.586 15H5c-1.654 0-3-1.346-3-3a1 1 0 011-1z" fill="#ffffff"></path></g></svg>
       </button>
       <span id="score-text">0%</span> правильных ответов
     </div>

--- a/style.css
+++ b/style.css
@@ -391,6 +391,13 @@ h1 {
   align-items: center;
   justify-content: center;
 }
+#reset-score svg {
+  width: 100%;
+  height: 100%;
+  fill: #fff;
+  stroke: #000;
+  stroke-width: 1px;
+}
 
 /* Check button container layout */
 .check-container {


### PR DESCRIPTION
## Summary
- swap the reset-score button icon
- give reset-score SVG full-size styling

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6888a2301d848330a8d021a2f808c7c5