### PR TITLE
Fix reset button alignment and icon display

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,14 +22,14 @@
     <div class="buttons">
       <div class="check-container">
         <button id="check-button" onclick="checkAnswer()">Gotovo</button>
-        <button id="auto-delay-button" onclick="toggleAutoDelay()">
+        <button id="auto-delay-button" onclick="toggleAutoDelay()" aria-label="Toggle auto delay">
           <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#000000" stroke-width="1"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C12.5523 20 13 20.4477 13 21C13 21.5523 12.5523 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 12.5523 21.5523 13 21 13C20.4477 13 20 12.5523 20 12C20 7.58172 16.4183 4 12 4ZM12 5C12.5523 5 13 5.44772 13 6V11.5858L13.7071 12.2929C14.0976 12.6834 14.0976 13.3166 13.7071 13.7071C13.3166 14.0976 12.6834 14.0976 12.2929 13.7071L11.2929 12.7071C11.1054 12.5196 11 12.2652 11 12V6C11 5.44772 11.4477 5 12 5ZM16.7071 15.2929C16.3166 14.9024 15.6834 14.9024 15.2929 15.2929C14.9024 15.6834 14.9024 16.3166 15.2929 16.7071L17.5858 19L15.2929 21.2929C14.9024 21.6834 14.9024 22.3166 15.2929 22.7071C15.6834 23.0976 16.3166 23.0976 16.7071 22.7071L19 20.4142L21.2929 22.7071C21.6834 23.0976 22.3166 23.0976 22.7071 22.7071C23.0976 22.3166 23.0976 21.6834 22.7071 21.2929L20.4142 19L22.7071 16.7071C23.0976 16.3166 23.0976 15.6834 22.7071 15.2929C22.3166 14.9024 21.6834 14.9024 21.2929 15.2929L19 17.5858L16.7071 15.2929Z" fill="#ffffff"></path></g></svg>
         </button>
       </div>
       <button id="new-example" onclick="loadExample(true)">Novi primjer</button>
     </div>
     <div class="score-percent">
-      <button id="reset-score" onclick="resetScore()">
+      <button id="reset-score" onclick="resetScore()" aria-label="Reset score">
         <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#000000" stroke-width="1"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M17 9a1 1 0 01-1-1c0-.551-.448-1-1-1H5.414l1.293 1.293a.999.999 0 11-1.414 1.414l-3-3a.999.999 0 010-1.414l3-3a.997.997 0 011.414 0 .999.999 0 010 1.414L5.414 5H15c1.654 0 3 1.346 3 3a1 1 0 01-1 1zM3 11a1 1 0 011 1c0 .551.448 1 1 1h9.586l-1.293-1.293a.999.999 0 111.414-1.414l3 3a.999.999 0 010 1.414l-3 3a.999.999 0 11-1.414-1.414L14.586 15H5c-1.654 0-3-1.346-3-3a1 1 0 011-1z" fill="#ffffff"></path></g></svg>
       </button>
       <span id="score-text">0%</span> правильных ответов

--- a/style.css
+++ b/style.css
@@ -379,6 +379,8 @@ h1 {
   font-family: 'Gloria Hallelujah', cursive;
   display: flex;
   align-items: center;
+  justify-content: center;
+  position: relative;
   gap: 0.5rem;
 }
 
@@ -386,17 +388,32 @@ h1 {
   width: 2rem;
   height: 2rem;
   padding: 0;
-  border-radius: 6px;
+  margin: 0;
+  border: none;
+  background: none;
+  box-shadow: none;
+  border-radius: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  left: calc(-2rem - 0.5rem);
+  top: 50%;
+  transform: translateY(-50%);
 }
 #reset-score svg {
+  display: block;
   width: 100%;
   height: 100%;
   fill: #fff;
   stroke: #000;
   stroke-width: 1px;
+}
+
+#score-text {
+  display: inline-block;
+  width: 4ch;
+  text-align: center;
 }
 
 /* Check button container layout */
@@ -431,6 +448,7 @@ h1 {
 }
 
 #auto-delay-button svg {
+  display: block;
   width: 100%;
   height: 100%;
   fill: #fff;


### PR DESCRIPTION
## Summary
- align reset button to the left and center percentage text
- ensure SVG icons fill their buttons
- fix width of score display
- add accessibility labels to icon buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888a616fcdc8330a8cf840ef1759fa7