### PR TITLE
Fix auto delay icon size

### DIFF
--- a/style.css
+++ b/style.css
@@ -449,8 +449,9 @@ h1 {
 
 #auto-delay-button svg {
   display: block;
-  width: 100%;
-  height: 100%;
+  width: 120%;
+  height: 120%;
+  margin: -10%;
   fill: #fff;
   stroke: #000;
   stroke-width: 1px;


### PR DESCRIPTION
## Summary
- enlarge auto-delay icon to match reset icon size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888bfdd1e388330b206de1d90301e9c