### PR TITLE
Adjust path size for auto-delay button icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -453,3 +453,10 @@ h1 {
   stroke: #000;
   stroke-width: 1px;
 }
+
+#auto-delay-button svg path {
+  transform-box: fill-box;
+  transform-origin: center;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- tweak auto-delay button's SVG path so it scales with the button

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6888c37cb2408330b4c4a92ad99150eb