### PR TITLE
Adjust auto-delay button svg icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -457,6 +457,5 @@ h1 {
 #auto-delay-button svg path {
   transform-box: fill-box;
   transform-origin: center;
-  width: 100%;
-  height: 100%;
+  transform: scale(1.15);
 }


### PR DESCRIPTION
## Summary
- enlarge auto-delay icon by scaling the path

## Testing
- `pip install svgpathtools --quiet`
- manual inspection of CSS

------
https://chatgpt.com/codex/tasks/task_e_6888c58e809c8330989d36f621375205