### PR TITLE
Improve translation layout and buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -256,11 +256,11 @@
          const t = currentExample.translations[l];
          if (t && t.length > maxLen) maxLen = t.length;
        });
-       el.style.minWidth = maxLen + 'ch';
-     } else {
-       el.style.minWidth = '';
-     }
-  }
+       el.style.maxWidth = maxLen + 'ch';
+      } else {
+       el.style.maxWidth = '';
+      }
+   }
 
   function createLanguageButtons() {
      const container = document.getElementById('language-button');
@@ -269,12 +269,12 @@
 
      const btn = document.createElement('button');
      btn.id = 'language-toggle';
-     btn.textContent = translationLang.toUpperCase();
+    btn.textContent = '(' + translationLang.toUpperCase() + ')';
      btn.addEventListener('click', () => {
        const idx = availableLangs.indexOf(translationLang);
        const next = (idx + 1) % availableLangs.length;
        translationLang = availableLangs[next];
-       btn.textContent = translationLang.toUpperCase();
+      btn.textContent = '(' + translationLang.toUpperCase() + ')';
        updateTranslation();
      });
      container.appendChild(btn);

--- a/style.css
+++ b/style.css
@@ -6,7 +6,8 @@ body {
   padding: 2rem;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
+  min-height: 100vh;
 }
 
 @keyframes heading-correct {
@@ -142,8 +143,11 @@ body {
   justify-content: center;
 }
 
+#translation-text {
+  display: inline-block;
+}
+
 .language-button {
-  margin-left: 0.5rem;
   font-style: normal;
 }
 


### PR DESCRIPTION
## Summary
- center the layout vertically and make container viewport height
- remove margin from language button styling
- constrain translation text width via inline-block element
- adjust width logic in `updateTranslation`
- show current translation language in parentheses

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889e1e791f08330ae1da7b61d41e50d