### PR TITLE
Restore central alignment and static width

### DIFF
--- a/script.js
+++ b/script.js
@@ -256,9 +256,9 @@
          const t = currentExample.translations[l];
          if (t && t.length > maxLen) maxLen = t.length;
        });
-       el.style.maxWidth = maxLen + 'ch';
+       el.style.minWidth = maxLen + 'ch';
       } else {
-       el.style.maxWidth = '';
+       el.style.minWidth = '';
       }
    }
 

--- a/style.css
+++ b/style.css
@@ -138,9 +138,6 @@ body {
   margin-bottom: 1rem;
   font-style: italic;
   text-align: center;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 #translation-text {
@@ -149,6 +146,7 @@ body {
 
 .language-button {
   font-style: normal;
+  margin-left: 0.5rem;
 }
 
 .language-button button {
@@ -446,11 +444,12 @@ h1 {
 
 /* Check button container layout */
 .check-container {
+  position: relative;
+  width: fit-content;
   display: flex;
   justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
   margin: 0.5rem;
+  padding-right: calc(2rem + 0.5rem);
 }
 
 .check-container button {
@@ -469,6 +468,10 @@ h1 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 #auto-delay-button svg {


### PR DESCRIPTION
## Summary
- keep translation width constant so the language switch button stays static
- revert translation container and buttons to previous centered layout
- revert check button container so auto-delay button overlays the check button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889e427189883309e8eba146f004dcf