### PR TITLE
Fix translation layout and auto-delay button position

### DIFF
--- a/script.js
+++ b/script.js
@@ -250,16 +250,7 @@
      const tr = currentExample.translations &&
        currentExample.translations[translationLang];
      el.textContent = tr || currentExample.translation || '';
-     if (currentExample.translations) {
-       let maxLen = 0;
-       availableLangs.forEach(l => {
-         const t = currentExample.translations[l];
-         if (t && t.length > maxLen) maxLen = t.length;
-       });
-       el.style.minWidth = maxLen + 'ch';
-      } else {
-       el.style.minWidth = '';
-      }
+    // allow the element to size naturally without a fixed minimum width
    }
 
   function createLanguageButtons() {

--- a/style.css
+++ b/style.css
@@ -131,12 +131,15 @@ body {
   margin-bottom: 2rem;
 }
 
+
 .translation {
   color: white;
   margin-bottom: 1rem;
   font-style: italic;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
   position: relative;
 }
 
@@ -146,12 +149,7 @@ body {
 
 .language-button {
   font-style: normal;
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 4ch;
-  margin-left: 0;
+  margin-top: 0.25rem;
 }
 
 .language-button button {
@@ -473,7 +471,7 @@ h1 {
   align-items: center;
   justify-content: center;
   position: absolute;
-  right: 0;
+  right: -4rem;
   top: 50%;
   transform: translateY(-50%);
 }


### PR DESCRIPTION
## Summary
- stack translation lines vertically and center the language toggle
- let translation text size naturally
- move the auto-delay button 4rem to the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688af1ed3104833085c37d48c5f3d6a4